### PR TITLE
Don't change uid/gid if we're already there

### DIFF
--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -443,16 +443,24 @@ impl ExecutableSpec {
 
         if let Some(target_uid) = self.uid {
             unsafe {
-                if libc::setuid(target_uid as libc::uid_t) < 0 {
-                    warn!("unable to set target UID: {:?}", Error::last_os_error());
+                // Check this to avoid a spurious log if we don't need to change,
+                // because we are already running as the target UID.
+                if libc::getuid() != target_uid {
+                    if libc::setuid(target_uid as libc::uid_t) < 0 {
+                        warn!("unable to set target UID: {:?}", Error::last_os_error());
+                    }
                 }
             }
         }
 
         if let Some(target_gid) = self.gid {
             unsafe {
-                if libc::setgid(target_gid as libc::gid_t) < 0 {
-                    warn!("unable to set target GID: {:?}", Error::last_os_error());
+                // Check this to avoid a spurious log if we don't need to change,
+                // because we are already running as the target GID.
+                if libc::getgid() != target_gid {
+                    if libc::setgid(target_gid as libc::gid_t) < 0 {
+                        warn!("unable to set target GID: {:?}", Error::last_os_error());
+                    }
                 }
             }
         }


### PR DESCRIPTION
If you are already running as the UID/GID you instructed `styrolite` to move you to, styrolite will warnlog with something like

```
[2025-06-02T20:07:18Z WARN  styrolite::wrap] unable to set target GID: Os { code: 1, kind: PermissionDenied, message: "Operation not permitted" }
```
Which is harmless/a nonissue in that case, but confusing.

This adds a simple check so we don't call `setgid/setuid` if we don't need to, because we're already under the right gid/uid.