### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @kaniini @azenla @bleggett @tycho


### PR DESCRIPTION
Adds CODEOWNERS. Pairs with the existing main ruleset, which already requires code-owner review.