### PR TITLE
Fix issue where cargo make isn't restored

### DIFF
--- a/.github/workflows/ci-code.yaml
+++ b/.github/workflows/ci-code.yaml
@@ -50,6 +50,13 @@ jobs:
         env:
           CARGO_MAKE_VERSION: ${{ steps.get-version.outputs.cargo_make_version }}
 
+      - name: Save cargo-make binary
+        if: steps.cache-cargo-make.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cargo/bin/cargo-make
+          key: ${{ runner.os }}-cargo-make-${{ steps.get-version.outputs.cargo_make_version }}
+
       - name: Verify cargo-make
         run: cargo make --version
 


### PR DESCRIPTION
In some cases, CI jobs on branches can't properly restore `cargo-make` from the Github cache, which leads to CI step failures (ex: https://github.com/edera-dev/styrolite/actions/runs/27627090980). Fix that by updating the `cache cargo make` thing to always update the cache on cache-miss, so downstream tasks always have a cached version to restore.