### PR TITLE
feat: masked and read-only container paths (OCI-style hardening)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,24 @@ pub struct CreateRequest {
     /// `/proc` will be mounted regardless of whether a mount specification is configured.
     pub mounts: Option<Vec<MountSpec>>,
 
+    /// Paths inside the container to mask so their contents are inaccessible,
+    /// applied after all mounts are in place (so freshly-mounted targets like
+    /// `/proc` are covered) but before pivot. A file target is covered by a
+    /// bind of `/dev/null`; a directory target is covered by an empty
+    /// read-only tmpfs. A target that does not exist is skipped, so the set may
+    /// be a superset not every rootfs/kernel populates. Mirrors the OCI
+    /// runtime-spec `maskedPaths`.
+    #[serde(default)]
+    pub masked_paths: Option<Vec<String>>,
+
+    /// Paths inside the container to make read-only while leaving their
+    /// contents readable, applied alongside `masked_paths`. Each existing
+    /// target is bind-mounted onto itself and recursively remounted read-only.
+    /// A target that does not exist is skipped. Mirrors the OCI runtime-spec
+    /// `readonlyPaths`.
+    #[serde(default)]
+    pub readonly_paths: Option<Vec<String>>,
+
     /// An optional set of resource limits.
     /// If this set is not provided, no cgroups will be configured.
     pub limits: Option<ResourceLimits>,
@@ -181,8 +199,13 @@ impl Capabilities {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum Config {
-    Create(CreateRequest),
-    Attach(AttachRequest),
+    // Both variants are boxed so the enum stays pointer-sized: `CreateRequest`
+    // and `AttachRequest` are large (hundreds of bytes each), and boxing only
+    // one would just move clippy's large_enum_variant complaint to the other.
+    // Box<T> serializes transparently, so the internally-tagged wire form is
+    // unchanged.
+    Create(Box<CreateRequest>),
+    Attach(Box<AttachRequest>),
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]
@@ -225,13 +248,13 @@ pub trait Configurable: Serialize + Validatable {
 
 impl Configurable for CreateRequest {
     fn encapsulate(self) -> Result<Config> {
-        Ok(Config::Create(self))
+        Ok(Config::Create(Box::new(self)))
     }
 }
 
 impl Configurable for AttachRequest {
     fn encapsulate(self) -> Result<Config> {
-        Ok(Config::Attach(self))
+        Ok(Config::Attach(Box::new(self)))
     }
 }
 

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -110,6 +110,95 @@ pub fn mount_setattr_fd(fd: &OwnedFd, recursive: bool, attr: &libc::mount_attr) 
     mount_setattr(fd.as_raw_fd(), "", flags, attr)
 }
 
+/// Join a container-absolute `path` under `rootfs`, avoiding a doubled
+/// separator. `path` is treated as rooted at the container's `/`.
+fn join_rootfs(rootfs: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        rootfs.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
+}
+
+/// Mask a single container path (OCI `maskedPaths` semantics): cover a file
+/// target with a bind of `/dev/null` (reads return EOF, writes are discarded)
+/// and a directory target with an empty read-only tmpfs. `path` is resolved
+/// under `rootfs`. A target that does not exist is skipped -- the default mask
+/// set is a superset that not every rootfs/kernel populates.
+///
+/// Must be called before pivot, while the original `/dev/null` is still
+/// reachable at its normal path.
+pub fn mask_path(rootfs: &str, path: &str) -> Result<()> {
+    let target = join_rootfs(rootfs, path);
+    let meta = match fs::symlink_metadata(&target) {
+        Ok(m) => m,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(anyhow!("stat {target}: {e}")),
+    };
+
+    let spec = if meta.is_dir() {
+        // Empty read-only tmpfs over the directory (nosuid/nodev/noexec).
+        MountSpec {
+            source: Some("tmpfs".to_string()),
+            target,
+            fstype: Some("tmpfs".to_string()),
+            bind: false,
+            recurse: false,
+            unshare: false,
+            safe: true,
+            create_mountpoint: false,
+            read_only: true,
+            data: Some("size=0k".to_string()),
+        }
+    } else {
+        // Bind /dev/null over the file. Not marked read-only or `safe`: the
+        // mask is the bind to /dev/null itself, and MOUNT_ATTR_NODEV would
+        // stop it from behaving as the device node it now is.
+        MountSpec {
+            source: Some("/dev/null".to_string()),
+            target,
+            fstype: None,
+            bind: true,
+            recurse: false,
+            unshare: false,
+            safe: false,
+            create_mountpoint: false,
+            read_only: false,
+            data: None,
+        }
+    };
+
+    spec.mount()
+}
+
+/// Make a single container path read-only (OCI `readonlyPaths` semantics)
+/// while leaving its contents readable: bind the target onto itself and
+/// recursively remount read-only. `path` is resolved under `rootfs`; a target
+/// that does not exist is skipped.
+pub fn make_readonly(rootfs: &str, path: &str) -> Result<()> {
+    let target = join_rootfs(rootfs, path);
+    match fs::symlink_metadata(&target) {
+        Ok(_) => {}
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(anyhow!("stat {target}: {e}")),
+    }
+
+    let spec = MountSpec {
+        source: Some(target.clone()),
+        target,
+        fstype: Some("none".to_string()),
+        bind: true,
+        recurse: true,
+        unshare: false,
+        safe: false,
+        create_mountpoint: false,
+        read_only: true,
+        data: None,
+    };
+
+    spec.mount()
+}
+
 impl Mountable for MountSpec {
     fn seal(&self) -> Result<()> {
         let tree = open_tree(
@@ -252,5 +341,25 @@ impl Mountable for MountSpec {
         env::set_current_dir("/")?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::join_rootfs;
+
+    #[test]
+    fn join_rootfs_avoids_double_separators() {
+        assert_eq!(
+            join_rootfs("/run/root", "/proc/kcore"),
+            "/run/root/proc/kcore"
+        );
+        // Trailing slash on rootfs and missing leading slash on path.
+        assert_eq!(join_rootfs("/run/root/", "proc/sys"), "/run/root/proc/sys");
+        // rootfs of "/" stays single-separator.
+        assert_eq!(
+            join_rootfs("/", "/proc/sysrq-trigger"),
+            "/proc/sysrq-trigger"
+        );
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -316,6 +316,22 @@ impl CreateRequestBuilder {
         self
     }
 
+    pub fn push_masked_path(mut self, path: impl Into<String>) -> CreateRequestBuilder {
+        self.config
+            .masked_paths
+            .get_or_insert_with(Vec::new)
+            .push(path.into());
+        self
+    }
+
+    pub fn push_readonly_path(mut self, path: impl Into<String>) -> CreateRequestBuilder {
+        self.config
+            .readonly_paths
+            .get_or_insert_with(Vec::new)
+            .push(path.into());
+        self
+    }
+
     pub fn push_mutation(mut self, spec: Mutation) -> CreateRequestBuilder {
         if self.config.mutations.is_none() {
             self.config.mutations = vec![].into();

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -477,6 +477,23 @@ impl CreateRequest {
             }
         }
 
+        // Apply OCI-style path hardening after every mount is in place (so
+        // freshly-mounted targets such as /proc are covered) but before pivot,
+        // while /dev/null is still reachable for masking. Targets are resolved
+        // under the new rootfs; missing ones are skipped.
+        if let Some(masked) = &self.masked_paths {
+            for path in masked {
+                crate::mount::mask_path(&rootfs, path)
+                    .map_err(|e| anyhow!("failed to mask {path}: {e}"))?;
+            }
+        }
+        if let Some(readonly) = &self.readonly_paths {
+            for path in readonly {
+                crate::mount::make_readonly(&rootfs, path)
+                    .map_err(|e| anyhow!("failed to make {path} read-only: {e}"))?;
+            }
+        }
+
         newroot
             .pivot()
             .map_err(|e| anyhow!("failed to pivot to new rootfs: {e}"))?;


### PR DESCRIPTION
Add `masked_paths` and `readonly_paths` to CreateRequest and apply them in pivot_fs after all mounts are in place -- so freshly-mounted targets like /proc are covered -- but before pivot, while /dev/null is still reachable for masking.

A masked file is covered by a bind of /dev/null (reads return EOF, writes are discarded); a masked directory by an empty read-only tmpfs. A read-only path is bind-mounted onto itself and recursively remounted read-only, leaving its contents readable. Targets that do not exist are skipped, so callers can pass a superset that not every rootfs/kernel populates. Builder gains push_masked_path / push_readonly_path.

This is the mechanism only; callers supply the path lists.