### PR TITLE
fix(deps): turn off logger regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,12 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive"] }
-env_logger = "0.11.10"
+# Disable the `regex` feature of `env_logger. We don't use it, and it pulls
+# in regex deps that nearly double the final binsize.
+env_logger = { version = "0.11.10", default-features = false, features = [
+  "auto-color",
+  "humantime",
+] }
 libc = "0.2.186"
 log = "0.4.30"
 mktemp-rs = "0.2.0"


### PR DESCRIPTION
`env_default` pulls in regex deps by default, which nearly double the size of the final binary and force downstream consumers to pull in `env_default` with that dep, all for log filtering stuff we never use.

So, disable that.